### PR TITLE
Add GitHub actions to check the commits

### DIFF
--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -1,11 +1,9 @@
-on:
-  push:
-    branches-ignore: [master, staging, trying]
+on: { push: { branches-ignore: [master, staging, trying] } }
 
 jobs:
   check:
     runs-on: ubuntu-latest
-    name: Fail on fixup commits
+    name: Check commits
     steps:
       - uses: actions/checkout@v2
       - name: Fetch all history so that later commands succeed
@@ -13,3 +11,6 @@ jobs:
       - name: Fail if any commits have a subject line starting fixup!
         run:
           "! git log --pretty=format:%s%n origin/master..HEAD | grep -q ^fixup!"
+      - name: Fail if any commits have a subject line starting squash!
+        run:
+          "! git log --pretty=format:%s%n origin/master..HEAD | grep -q ^squash!"

--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -14,3 +14,5 @@ jobs:
       - name: Fail if any commits have a subject line starting squash!
         run:
           "! git log --pretty=format:%s%n origin/master..HEAD | grep -q ^squash!"
+      - name: Fail if any commits are a merge
+        run: test -z "$(git rev-list --merges origin/master..HEAD)"

--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches-ignore: [master, staging, trying]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Fail on fixup commits
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch all history so that later commands succeed
+        run: git fetch --prune --unshallow
+      - name: Fail if any commits have a subject line starting fixup!
+        run:
+          "! git log --pretty=format:%s%n origin/master..HEAD | grep -q ^fixup!"


### PR DESCRIPTION
Keep git history simple and easy to follow, by avoiding avoid three things:

1. commit messages starting with fixup!
2. commit messages starting with squash!
3. merge commits inside a PR

The first two can be avoided by using `git rebase --autosquash`; they are likely created with `git commit --fixup` or `git commit --squash`.

The third can be avoided by rebasing on top of a master after updates rather than merging in changes.


